### PR TITLE
fix off by one error

### DIFF
--- a/torrent.py
+++ b/torrent.py
@@ -199,7 +199,7 @@ def get_magnet():
                 magnet_link = []
                 for link in magnet_result:
                     magnet_link.append(link['href'])
-                download_link = magnet_link[index]
+                download_link = magnet_link[index-1]
 
                 print(f'\nYour selected movie: {name_movie}Size: {size_movie}')
                 time.sleep(1)


### PR DESCRIPTION
not sure if the format on the page has changed, but currently it is showing the wrong magnet link. So e.g. you select index 3 it will display and download the magnet link for index 4. This fixes it for me